### PR TITLE
fix: swap to native AI binding

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
 		"test": "vitest"
 	},
 	"dependencies": {
-		"@cloudflare/ai": "^1.0.15",
 		"itty-router": "^4.2.2"
 	},
 	"devDependencies": {

--- a/routes/audio.js
+++ b/routes/audio.js
@@ -1,7 +1,4 @@
-import { Ai } from '@cloudflare/ai';
-
 export const transcriptionHandler = async (request, env) => {
-	const ai = new Ai(env.AI);
 	let model = '@cf/openai/whisper';
 	let error = null;
 	// don't need anything else as openai just gives back text
@@ -17,7 +14,7 @@ export const transcriptionHandler = async (request, env) => {
 			const input = {
 				audio: [...new Uint8Array(blob)],
 			};
-			const resp = await ai.run(model, input);
+			const resp = await env.AI.run(model, input);
 			return Response.json({
 				text: resp.text,
 			});
@@ -47,7 +44,6 @@ function getLanguageId(text) {
 }
 
 export const translationHandler = async (request, env) => {
-	const ai = new Ai(env.AI);
 	let model = '@cf/openai/whisper';
 	let error = null;
 
@@ -62,9 +58,9 @@ export const translationHandler = async (request, env) => {
 			const input = {
 				audio: [...new Uint8Array(blob)],
 			};
-			const resp = await ai.run(model, input);
+			const resp = await env.AI.run(model, input);
 
-			const language_id_resp = await ai.run('@cf/meta/llama-2-7b-chat-int8', {
+			const language_id_resp = await env.AI.run('@cf/meta/llama-2-7b-chat-int8', {
 				messages: [
 					{
 						role: 'user',
@@ -78,7 +74,7 @@ export const translationHandler = async (request, env) => {
 				],
 			});
 
-			const translation_resp = await ai.run('@cf/meta/m2m100-1.2b', {
+			const translation_resp = await env.AI.run('@cf/meta/m2m100-1.2b', {
 				text: resp.text,
 				source_lang: getLanguageId(language_id_resp.response),
 				target_lang: 'english',

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1,7 +1,4 @@
-import { Ai } from '@cloudflare/ai';
-
 export const chatHandler = async (request, env) => {
-	const ai = new Ai(env.AI);
 	let model = '@cf/mistral/mistral-7b-instruct-v0.1';
 	let messages = [];
 	let error = null;
@@ -87,7 +84,7 @@ export const chatHandler = async (request, env) => {
 			});
 
 			// for now, nothing else does anything. Load the ai model.
-			const aiResp = await ai.run(model, { stream: json.stream, messages });
+			const aiResp = await env.AI.run(model, { stream: json.stream, messages });
 			// Piping the readableStream through the transformStream
 			return json.stream ? new Response(aiResp.pipeThrough(transformer), {
 				headers: {

--- a/routes/completion.js
+++ b/routes/completion.js
@@ -1,7 +1,4 @@
-import { Ai } from '@cloudflare/ai';
-
 export const completionHandler = async (request, env) => {
-	const ai = new Ai(env.AI);
 	let model = '@cf/mistral/mistral-7b-instruct-v0.1';
 
 	const created = Math.floor(Date.now() / 1000);
@@ -25,7 +22,7 @@ export const completionHandler = async (request, env) => {
 				}
 			}
 			// for now, nothing else does anything. Load the ai model.
-			const aiResp = await ai.run(model, { prompt: json.prompt });
+			const aiResp = await env.AI.run(model, { prompt: json.prompt });
 			return Response.json({
 				id: uuid,
 				model,

--- a/routes/embeddings.js
+++ b/routes/embeddings.js
@@ -1,7 +1,4 @@
-import { Ai } from '@cloudflare/ai';
-
 export const embeddingsHandler = async (request, env) => {
-	const ai = new Ai(env.AI);
 	let model = '@cf/baai/bge-base-en-v1.5';
 	let error = null;
 
@@ -12,7 +9,7 @@ export const embeddingsHandler = async (request, env) => {
 			// 	model = json.model;
 			// }
 
-			const embeddings = await ai.run(model, {
+			const embeddings = await env.AI.run(model, {
 				text: json.input,
 			});
 

--- a/routes/image.js
+++ b/routes/image.js
@@ -1,11 +1,8 @@
-import { Ai } from '@cloudflare/ai';
-
 import { uint8ArrayToBase64 } from '../utils/converters';
 import { uuidv4 } from '../utils/uuid';
 import { streamToBuffer } from '../utils/stream';
 
 export const imageGenerationHandler = async (request, env) => {
-    const ai = new Ai(env.AI);
     let model = '@cf/stabilityai/stable-diffusion-xl-base-1.0';
     let format = 'url';
     let error = null;
@@ -27,7 +24,7 @@ export const imageGenerationHandler = async (request, env) => {
                 prompt: json.prompt,
             };
 
-            const respStream = await ai.run(model, inputs); // Get the response stream
+            const respStream = await env.AI.run(model, inputs); // Get the response stream
             const respBuffer = await streamToBuffer(respStream); // Buffer the stream into memory
 
             if (format === 'b64_json') {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,11 +1,6 @@
 name = "openai-cf"                # todo
 main = "index.js"
-compatibility_date = "2022-05-03"
-
-compatibility_flags = [
-	"transformstream_enable_standard_constructor",
-	"streams_enable_constructors",
-]
+compatibility_date = "2024-05-06"
 
 [ai]
 binding = "AI" # i.e. available in your Worker on env.AI


### PR DESCRIPTION
As of 2024-04-11, there's no need to use the `@cloudflare/ai` package and it's deprecated:

https://developers.cloudflare.com/workers-ai/changelog/

This swaps the code over to use the native binding on `env.AI` directly. No other code changes are needed.